### PR TITLE
Add subcommunities to REX event viewer

### DIFF
--- a/components/t-rex/TRexApp.tsx
+++ b/components/t-rex/TRexApp.tsx
@@ -206,14 +206,19 @@ function EventCard(props: EventCardProps) {
                 style={{ display: "flex", flexWrap: "wrap" }}
             >
                 <ColoredBadge
-                    className="badge badge--primary margin-right--md"
+                    className="badge badge--primary margin-right--sm"
                     color={props.colors.dorms.get(props.event.dorm)}
                 >
                     {props.event.dorm}
                 </ColoredBadge>
+                {props.event.group && (
+                    <div className="margin-right--sm">
+                        🏘️ {props.event.group}
+                    </div>
+                )}
                 <div
                     style={{ color: "var(--ifm-color-secondary-darkest)" }}
-                    className="margin-right--sm"
+                    className="margin-right--sm margin-left--sm"
                 >
                     🕒 {dateStrings.duration}
                 </div>

--- a/components/t-rex/types.ts
+++ b/components/t-rex/types.ts
@@ -20,6 +20,8 @@ type TRexAPIColors = {
 type TRexEvent = {
     name: string;
     dorm: string;
+    /** The subcommunity or living group hosting this event, if any */
+    group: string | null;
     location: string;
     start: Date;
     end: Date;

--- a/src/pages/rex/events.tsx
+++ b/src/pages/rex/events.tsx
@@ -37,6 +37,7 @@ export default function Events() {
                     keys: [
                         { name: "name", weight: 2 },
                         "dorm",
+                        "group",
                         "location",
                         "tags",
                         { name: "description", weight: 0.5 },


### PR DESCRIPTION
- Add `group` to TRexEvent type
- Show group next to the dorm, with a 🏘️ icon, if it exists
  <img width="361" alt="Screenshot 2023-07-23 at 23 01 11" src="https://github.com/mit-dormcon/website/assets/7855233/abe55215-cfe6-4f26-b012-e97a881714d5">
- Make group searchable in Fuse
