### PR TITLE
Add REX event timeline via embed of Eventful

### DIFF
--- a/components/t-rex/EventfulEmbed.module.css
+++ b/components/t-rex/EventfulEmbed.module.css
@@ -1,0 +1,30 @@
+.fullscreen_link {
+    box-sizing: border-box;
+    display: block;
+    background: #040408;
+    color: #fff;
+    width: 20em;
+    float: right;
+    text-align: center;
+    padding: 0.3em 0.5em;
+    clip-path: polygon(
+        0% 5em,
+        5em 0%,
+        calc(100% - 5em) 0%,
+        100% 5em,
+        100% 100%,
+        0% 100%
+    );
+    margin-bottom: -2px;
+}
+.fullscreen_link > span {
+    padding-left: 1em;
+    padding-right: 0.3em;
+}
+
+.embed {
+    /* position: absolute; */
+    width: 90vw;
+    margin-left: calc(50% - 45vw);
+    height: calc(100vh - 14em);
+}

--- a/components/t-rex/EventfulEmbed.tsx
+++ b/components/t-rex/EventfulEmbed.tsx
@@ -1,0 +1,13 @@
+import Link from "@docusaurus/Link"
+import styles from "./EventfulEmbed.module.css"
+
+const EVENTFUL_URL = new URL("https://scidev5.github.io/eventful")
+const EVENTFUL_SCHEDULE_ID = "rex"
+EVENTFUL_URL.searchParams.append("event", EVENTFUL_SCHEDULE_ID)
+
+export function EventfulEmbed() {
+    return (<div>
+        <Link className={styles.fullscreen_link} to={EVENTFUL_URL.toString()}>fullscreen <span>&#x26F6;</span></Link>
+        <iframe title="REX Events - Eventful" className={styles.embed} src={EVENTFUL_URL.toString() + "&is_embed"} />
+    </div>)
+}

--- a/components/t-rex/EventfulEmbed.tsx
+++ b/components/t-rex/EventfulEmbed.tsx
@@ -7,7 +7,15 @@ EVENTFUL_URL.searchParams.append("event", EVENTFUL_SCHEDULE_ID)
 
 export function EventfulEmbed() {
     return (<div>
-        <Link className={styles.fullscreen_link} to={EVENTFUL_URL.toString()}>fullscreen <span>&#x26F6;</span></Link>
-        <iframe title="REX Events - Eventful" className={styles.embed} src={EVENTFUL_URL.toString() + "&is_embed"} />
+        <Link
+            className={styles.fullscreen_link}
+            target="_self"
+            to={EVENTFUL_URL.toString()}
+        >fullscreen <span>&#x26F6;</span></Link>
+        <iframe
+            title="REX Events - Eventful"
+            className={styles.embed}
+            src={EVENTFUL_URL.toString() + "&is_embed"}
+        />
     </div>)
 }

--- a/components/t-rex/TRexApp.tsx
+++ b/components/t-rex/TRexApp.tsx
@@ -66,16 +66,15 @@ export const useRexData = () => {
     return swr;
 };
 
-export function TRexHeadline() {
-    const { data, isLoading } = useRexData();
+export function TRexHeadline({ is_timeline }: { is_timeline?: boolean }) {
+    const { data } = useRexData();
     const { colorMode } = useColorMode();
 
+    const gradient = colorMode === "light"
+        ? lightGradient
+        : darkGradient;
     const headlineStyle: CSSProperties = {
-        backgroundImage: `linear-gradient(45deg, ${
-            colorMode === "light"
-                ? lightGradient.join(", ")
-                : darkGradient.join(", ")
-        })`,
+        backgroundImage: `linear-gradient(45deg, ${gradient.join(", ")})`,
         WebkitBackgroundClip: "text",
         backgroundClip: "text",
         display: "inline-block",
@@ -83,12 +82,37 @@ export function TRexHeadline() {
         color: "transparent",
     };
 
+
     return (
-        !isLoading && (
+        <div style={{
+            display: "contents",
+        }}>
             <Heading as="h1" style={headlineStyle} key={0}>
-                {data?.name}
+                {data?.name ?? "loading..."} {is_timeline ? "[Timeline]" : ""}
             </Heading>
-        )
+            <Link
+                to={is_timeline ? "/rex/events" : "/rex/timeline"}
+                className={clsx(
+                    "button button--primary button--lg",
+                    styles.heroButton,
+                )}
+                style={{
+                    backgroundImage: `linear-gradient(45deg, ${[
+                        ...gradient,
+                        gradient[0],
+                    ].join(",")})`,
+                    transition: "0.5s",
+                    border: "none",
+                    ...is_timeline ? {
+                        verticalAlign: "initial",
+                        marginLeft: "2em",
+                    } : {
+                        marginTop: "1.5em",
+                        float: "right",
+                    },
+                }}
+            >View as {is_timeline ? "List" : "Timeline"}</Link>
+        </div>
     );
 }
 

--- a/src/pages/rex/timeline.mdx
+++ b/src/pages/rex/timeline.mdx
@@ -1,0 +1,14 @@
+---
+title: REX Events Timeline
+description:
+    The other one page for all REX events (now in a new and fancy timeline
+    format).
+---
+
+import { TRexHeadline } from "../../../components/t-rex/TRexApp";
+import { EventfulEmbed } from "../../../components/t-rex/EventfulEmbed";
+
+<TRexHeadline is_timeline />
+<EventfulEmbed />
+
+[Maintained by SciDev (skylarh@mit.edu) on GitHub.](https://github.com/SciDev5/eventful)


### PR DESCRIPTION
Add a timeline view for REX events by embedding iframe linked to https://github.com/SciDev5/eventful.